### PR TITLE
Add GitHub Pages schedule viewer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenSauce Schedule</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+<h1>OpenSauce 2025 Schedule</h1>
+<a class="download" href="opensauce_schedule.ics" download>Download ICS</a>
+</header>
+<nav id="tabs">
+<button data-day="Friday" class="active">Friday, July 25</button>
+<button data-day="Saturday">Saturday, July 26</button>
+<button data-day="Sunday">Sunday, July 27</button>
+</nav>
+<section id="content"></section>
+<script src="main.js"></script>
+</body>
+</html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,0 +1,34 @@
+async function loadSchedule() {
+  const response = await fetch('../opensauce_schedule.json');
+  const data = await response.json();
+  const content = document.getElementById('content');
+  const tabs = document.querySelectorAll('#tabs button');
+
+  function render(day) {
+    content.innerHTML = '';
+    data[day].forEach(ev => {
+      const div = document.createElement('div');
+      div.className = 'event';
+      div.innerHTML = `
+        <div class="time">${ev.time} ${ev.duration}</div>
+        <h3>${ev.title}</h3>
+        <div class="stage">${ev.stage}</div>
+        <p>${ev.description}</p>
+        <div class="speakers">${ev.speakers.join(', ')}</div>
+      `;
+      content.appendChild(div);
+    });
+  }
+
+  tabs.forEach(btn => {
+    btn.addEventListener('click', () => {
+      tabs.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      render(btn.dataset.day);
+    });
+  });
+
+  render('Friday');
+}
+
+loadSchedule();

--- a/docs/opensauce_schedule.ics
+++ b/docs/opensauce_schedule.ics
@@ -1,0 +1,635 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//OpenSauce Schedule//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:20250725T093000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T093000
+DTEND:20250725T094000
+SUMMARY:Welcome to Open Sauce with William Osman
+DESCRIPTION:Join the official kickoff of Open Sauce Year 3 with inventor and creator William Osman. This session will offer a quick look at the creator culture that drives innovation, audience connection, and creative business growth.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T094000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T094000
+DTEND:20250725T100500
+SUMMARY:Scaling Content Across Borders
+DESCRIPTION:As platforms grow globally, smart creators are discovering opportunity to distribute everywhere. This session lays out the advantages for global content expansion: greater ad revenue, new sponsorship options, and increased audience growth. Learn which tools, partners, and platforms are helping creators scale internationally - without scaling production.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T100500-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T100500
+DTEND:20250725T103500
+SUMMARY:If YouTube Died Tomorrow, Would Your Business?
+DESCRIPTION:You don’t own your followers. And if the algorithm turns on you—or your platform disappears—what happens next? This session explores how creators are future-proofing their business by owning their audiences and monetizing beyond the core social platforms. Learn how to take control of your community, revenue, and future - and stop relying on rented land.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T103500-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T103500
+DTEND:20250725T110000
+SUMMARY:Fireside Chat with Alex Wellen, President QVC
+DESCRIPTION:Commerce has entered a bold new era. As the original disruptor in retail innovation, QVC Group is building the future of live, social, and immersive shopping. In this fireside chat, Alex Wellen, President and Chief Growth Officer of QVC Group, joins Jim Louderback to explore how the company is redefining the commerce experience—scaling authentic storytelling, reaching new consumers, empowering fresh voices, and setting the standard for the future of shoppable media across all types of products – including those from makers, builders, scientists and geeks.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T110000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T110000
+DTEND:20250725T113000
+SUMMARY:Fireside Chat with Kevin Kelly and William Osman
+DESCRIPTION:Kevin Kelly helped define digital optimism and shaped how we think about technology, communities, and creativity. In this live podcast recording and fireside chat with maker-creator William Osman, the Wired founding executive editor explore the real meaning behind 1,000 True Fans, the power of an “audience of one,” and why a little optimism is a good thing. Expect stories, frameworks, and timeless advice for everyone navigating the next era of the internet and life itself.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T113000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T113000
+DTEND:20250725T120000
+SUMMARY:The Science of Memes and the Art of Relevance
+DESCRIPTION:What do an etymology expert and an engineering creator have in common? Memes. In this surprising and fun session, Etymology Nerd Adam Aleksic and Patrick Lacey from Tier Zoo explore how meme culture powers both virality and connection. From shifting language to unexpected content formats, they’ll explore what it really takes to stay relevant—and respected—online. You’ll learn how to spot high-potential trends early, apply meme logic to serious content, and use humor to build lasting audience engagement.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T120000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T120000
+DTEND:20250725T130000
+SUMMARY:LUNCH
+DESCRIPTION:
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T122000-Breakout3@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T122000
+DTEND:20250725T125000
+SUMMARY:Roundtable with Tyler Chou
+DESCRIPTION:Got a legal question? Wondering abou the law and creators? Bring your questions, thoughs and ideas to this round-table discussion with creator, lawyer, manager and creator advocate Tyler Chou.
+LOCATION:Breakout 3
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T122000-Breakout1@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T122000
+DTEND:20250725T125000
+SUMMARY:AMA With NASA Astronaut Matthew Dominick
+DESCRIPTION:Straight from NASA to our stage, Matthew Dominick answers your boldest, weirdest, and most ambitious space questions - along with talking about what it's like to be a creator in space.
+LOCATION:Breakout 1
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T122000-Breakout2@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T122000
+DTEND:20250725T125000
+SUMMARY:A Day in the life of Mark Rober's Creative Team
+DESCRIPTION:Go behind the scenes with Mark Rober’s creative team as they share insights into their workflow, problem-solving techniques, and the magic behind their viral projects. Bring your questions and ideas to this interactive AMA session and explore wild ideas, innovative production processes and more!
+LOCATION:Breakout 2
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T130000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T130000
+DTEND:20250725T133000
+SUMMARY:YouTube Algorithm Secrets - 2025
+DESCRIPTION:YouTube's creator liaison and editor Rene Ritchie and YouTube product manager Todd Beaupre know more about building success on YouTube than just about anyone else. In this session they'll share the deep secrets of success for July 2025, including why the algorithm doesn't hate you, how AI is changing discovery and recommendations, the key numbers and KPIs to REALLY focus on, the unique characteristics of Shorts, YouTube on the big screen and much more! Get ready to really understand how the YouTube algorithm works from the inside experts at YouTube!
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T133000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T133000
+DTEND:20250725T135500
+SUMMARY:GM's Creator Playbook
+DESCRIPTION:For GM, the road to the future isn’t just about EVs and autonomous driving – it’s about transforming how they engage with creators and redefine their brand for a digital-first world. Jessica Wang, Executive Director of Content Strategy at GM and former YouTube executive, shares how the legacy automaker is moving beyond traditional influencer campaigns to deeper, more authentic partnerships that treat creators like true creative collaborators. Learn why GM is betting on creators as strategic storytellers, how they’re building relationships beyond the automotive world, and what this approach means for brands looking to connect with diverse, engaged audiences.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T135500-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T135500
+DTEND:20250725T142500
+SUMMARY:What Creators Wish Brands Knew
+DESCRIPTION:Brands love working with creators—until they don’t. Misaligned expectations, bad briefs, and clunky approval processes can turn a dream deal into a disaster. In this session, top creators pull back the curtain on what brands get wrong (and right) when collaborating with influencers. From creative freedom to fair pay to authentic storytelling, hear firsthand what creators need from brands to deliver their best work—and why some partnerships fail before they even begin. If you’re a brand looking to build better, more effective creator relationships, this is the conversation you can’t afford to miss.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T142500-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T142500
+DTEND:20250725T145000
+SUMMARY:What Brands Wish Creators Knew - Kamal Bhandal
+DESCRIPTION:What makes a creator stand out—or get cut? Kamal Bhandal, SVP of Global Invisalign Brand at Align Technology, shares what brands really look for, what kills a deal, and how creators can position themselves for long-term partnerships. Walk away with clear, insider tips to land brand deals and avoid common missteps.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T145000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T145000
+DTEND:20250725T152000
+SUMMARY:Thriving as a Creator in the Age of AI
+DESCRIPTION:These creators aren’t scared of AI, they're adapting and thriving. 3 top creators share how they are integrating AI into their workflows today, and how they plan to differentiate their content from AI-generated slop tomorrow. From content production to audience growth, new formats and digital twins, they’ll share what tools are working, what’s still broken, and how they'll collaborate and compete with AI in the future.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T153000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T153000
+DTEND:20250725T161000
+SUMMARY:AFTERNOON BREAK
+DESCRIPTION:
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T153500-Breakout1@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T153500
+DTEND:20250725T160500
+SUMMARY:Round Table With Rene Ritchie
+DESCRIPTION:Join this round table / AMA with Rene Ritchie to talk YouTube algorithms, creating content and really anything on your mind!
+LOCATION:Breakout 1
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T153500-Breakout3@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T153500
+DTEND:20250725T160500
+SUMMARY:Round Table Q&A: Setting Yourself Up for Brand Partnerships Success
+DESCRIPTION:This facilitated discussion brings creators together to unpack the full brand partnerships journey. Whether you're represented or independent, you'll walk through the entire cycle—from strategy to pitch to execution and renewal. Guided by Ben Smith from Smooth Media, you’ll learn how to better define your audience, build effective media kits, and sustain long-term relationships. Share your experience, ask questions, and leave with tactical insights to help you start working with your dream brands.
+LOCATION:Breakout 3
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T153500-Breakout2@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T153500
+DTEND:20250725T160500
+SUMMARY:Roundtable Conversation: What is a Creator in the Age of AI
+DESCRIPTION:AI is reshaping the creative process. This roundtable, led by YC Sun and Dan Perkel of IDEO, offers an interactive forum for creators, marketers and experts to discuss the practical, personal, and ethical questions raised in “Thriving as a Creator in the Age of AI.” Bring your ideas, frustrations, questions and code. You'll leave with new strategies, peer insights, and possible collaborations.
+LOCATION:Breakout 2
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T161000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T161000
+DTEND:20250725T164000
+SUMMARY:Explaining the Universe One Click at a Time
+DESCRIPTION:From backyard explosions to big-bang theories, science hits different when it’s told by creators who love to tinker, test, and ask “what if?” This session dives into how hands-on creators and lifelong explainers are turning curiosity into content that sticks—and why making people feel science might matter more than making them memorize it. Get practical strategies to create, build, fund, and scale science communication in a platform-first world.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T164000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T164000
+DTEND:20250725T170500
+SUMMARY:From Tech Journalist to Brand Insider
+DESCRIPTION:Dan Ackerman spent years running major tech sites, including Gizmodo and CNET. Now he’s internal editor-in-chief at MicroCenter. What’s it like to go from covering the industry to working inside it? Joined by creator and MicroCenter SuperFan Michael Reeves, this session explores the evolving role of media, the rise of internal creators, and what the future looks like for building PCs and telling tech stories.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T170500-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T170500
+DTEND:20250725T173000
+SUMMARY:Likes Don’t Pay Rent - Fireside Chat with Patreon COO Paige Fitzgerald
+DESCRIPTION:This fireside chat with Patreon COO Paige Fitzgerald explores how creators are moving beyond ad models and algorithm churn to build real, recurring revenue. Drawing on insights from Patreon’s latest State of the Creator report and real world examples, the session will explore what sustainable success looks like today. Whether you're a creator, a platform builder, or a brand investing in talent, this conversation offers a clear look at what it takes to build a lasting creative business.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T173000-IndustryStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T173000
+DTEND:20250725T180000
+SUMMARY:From YouTube Clickbait to Real Engineering
+DESCRIPTION:We’re closing out industry day with a conversation with top creators who are pushing the boundaries of internet innovation through hands-on engineering and practical product development. From prototyping physical products to launching new tools with AI, this session dives into the serious side of making on the internet. You'll leave with insight into how creators are evolving beyond content into real-world problem-solving and what’s inspiring them to keep building.
+LOCATION:Industry Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250725T183000-Off-Site@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250725T183000
+DTEND:20250725T203000
+SUMMARY:Industry Reception
+DESCRIPTION:
+LOCATION:Off-Site
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T103000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T103000
+DTEND:20250726T111500
+SUMMARY:Safety Third: LIVE!
+DESCRIPTION:Safety Third but it's LIVE! The hosts (and some guests) share stories and rant while pretending to talk about science.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T110000-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T110000
+DTEND:20250726T113000
+SUMMARY:Innovating In A Niche
+DESCRIPTION:Some people chase trends, but these creators have built strong, loyal audiences by sticking to what they love and finding others who love it too. Hear how to turn niche ideas into standout content.
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T111500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T111500
+DTEND:20250726T114500
+SUMMARY:Prototyping to Product
+DESCRIPTION:Making one cool thing for a YouTube video is tough enough, but turning that idea into 10,000 units is a whole different challenge. Learn how these creators have taken their custom-built projects from prototype to product.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T120000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T120000
+DTEND:20250726T124500
+SUMMARY:The BackYard - Agains
+DESCRIPTION:We’re back! Join as the cast of The Yard returns for more Backyard Science in the squeak-uel we've all been waiting for.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T124500-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T124500
+DTEND:20250726T133000
+SUMMARY:Team Rocket
+DESCRIPTION:Join us to nerd out over thrust vectors, propellants, shock diamonds, and more rocket words! It's gonna rock(et).
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T130000-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T130000
+DTEND:20250726T133000
+SUMMARY:Robotics and Animatronics!
+DESCRIPTION:What if the robots could move?
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T133000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T133000
+DTEND:20250726T140000
+SUMMARY:Could AI Make This Panel?
+DESCRIPTION:It - made - this - description!
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T133000-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T133000
+DTEND:20250726T141500
+SUMMARY:Planes, Trains, and Automobiles
+DESCRIPTION:Walking is overrated. This gang of creators prefers to drive, fly and float their way around.
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T133000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T133000
+DTEND:20250726T140000
+SUMMARY:It's All About Chemistry
+DESCRIPTION:We all know "Chemistry is the scientific study of matter, its properties, and how it changes during chemical reactions. It explores the building blocks of the universe such as atoms and molecules and how they interact to form everything from water to DNA. Chemistry connects the physical world with biological and environmental systems", and this panel connects you with your favorite chemistry creators. Will they bond?
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T140000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T140000
+DTEND:20250726T143000
+SUMMARY:Streaming AMA
+DESCRIPTION:It doesn't get more live than this. Chat with top streaming creators in this Q&A panel. Questions for the panel must be submitted in advance via the event app.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T140000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T140000
+DTEND:20250726T150000
+SUMMARY:Let's make a game in an hour
+DESCRIPTION:
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T141500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T141500
+DTEND:20250726T144500
+SUMMARY:Unconventional Materials
+DESCRIPTION:Wood, metal, and plastic are fine...but why stop there? How to make something from anything.
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T143000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T143000
+DTEND:20250726T150000
+SUMMARY:State of The Union
+DESCRIPTION:Over the past two decades, content creation has evolved from webcam vlogs into a multi-billion-dollar industry. Join us as we chat about the shifts in platforms, audiences, algorithms, and where we might be headed next.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T150000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T150000
+DTEND:20250726T153000
+SUMMARY:Super Villain Inc.
+DESCRIPTION:Trapped in an entry level job, creators are forced to innovate at the will of an evil corporate overlord. Watch as they navigate a game of ethics, corporate bureaucracy, and the laws of physics. Will there be synergy?
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T151500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T151500
+DTEND:20250726T160000
+SUMMARY:Meet the Bot Builders, ask them anything!
+DESCRIPTION:A discussion with some of the most famous builders in BattleBots. We will talk about BattleBots Faceoffs and some recent YouTube creators and bot builders collaborations then open it up to questions. Builders: Ray Billings: Tombstone (World Champion and Most Destructive Robot Award), Leanne Cushing: Valkyrie (Most Destructive Robot Award), Nick Dobrikov: Manta, Jen Herochender: Hijinx, Aren Hill: Tantrum, Blip (World Champion), Bunny Liaw: Malice, Zach Lytle: Skorpios and Derek Tran: Cobalt, Gigabyte
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T153000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T153000
+DTEND:20250726T163000
+SUMMARY:Why you need a producer
+DESCRIPTION:
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T160000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T160000
+DTEND:20250726T164500
+SUMMARY:Carp Tank
+DESCRIPTION:Open Sauce exhibitors team up with creators to pitch their projects to a panel of vicious business carp. Will the ideas (and their inventors) sink or swim under the pressure?
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T163000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T163000
+DTEND:20250726T170000
+SUMMARY:gnireenignE: Reverse Engineering
+DESCRIPTION:.gnireenigne s'taht won ,rehtegot kcab meht gnittup ,trapA sgniht gnikaT
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T170000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T170000
+DTEND:20250726T173000
+SUMMARY:3D Printing Hot Takes
+DESCRIPTION:From failed first layers, to funky filaments, and a billion “Benchy’s”: these creators' and their 3D printing opinions are like onions (they have layers). Join them for a layered discussion about printers, slicers, and so many layers.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T170000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T170000
+DTEND:20250726T174500
+SUMMARY:Are you dumber than a sixth grader?
+DESCRIPTION:Four creators vs four sixth graders. Who will win?
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250726T173000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250726T173000
+DTEND:20250726T180000
+SUMMARY:Doing It The Hard Way (Ye' Olde Makers)
+DESCRIPTION:Ignoring the advances of technology over the past few decades is… a choice.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T103000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T103000
+DTEND:20250727T110000
+SUMMARY:YouTube Shop Talk: Ask Us Anything!
+DESCRIPTION:Talk shop with top creators in this Q&A panel. Questions for the panel must be submitted in advance via the event app.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T103000-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T103000
+DTEND:20250727T110000
+SUMMARY:Movie Magic: VFX
+DESCRIPTION:These magicians WILL share their secrets.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T104500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T104500
+DTEND:20250727T113000
+SUMMARY:Experimental Panel Title
+DESCRIPTION:Never let them know your next move. When these creators post, you never know what you’re gonna get. Come learn about how a sidequest can spiral into something bigger and what to do when you’re interested in everything.
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T110000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T110000
+DTEND:20250727T113000
+SUMMARY:Mammoth Mistake? Conservation and Human Interference
+DESCRIPTION:From ancient extinction to modern ecosystems, the line between conservation and interference is blurrier than ever. Should we bring species back? How do we protect what’s still here? And what role should humans play in shaping nature’s future?
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T111500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T111500
+DTEND:20250727T114500
+SUMMARY:Developing Content on Developing Games
+DESCRIPTION:These creators know it ain’t all fun and games. Find out how these developer creators juggle developing games and developing content about developing games as this panel develops.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T114500-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T114500
+DTEND:20250727T121500
+SUMMARY:The Future of Animation
+DESCRIPTION:From hand-drawn cells to AI-assisted workflows, animation is evolving faster than ever. This panel brings together creators who are pushing the boundaries of style, technology, and storytelling. Explore where animation is headed, how it is being made, and what the next generation of animators and audiences can expect.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T121500-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T121500
+DTEND:20250727T130000
+SUMMARY:Learning is Fun: Educating on Educational Content
+DESCRIPTION:Science education doesn’t have to be dry. Learn how these creators navigate mixing entertainment with education.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T124500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T124500
+DTEND:20250727T133000
+SUMMARY:Creator Feud
+DESCRIPTION:Join us for a second annual game of Creator Feud, where your answers shape the game! Be sure to complete our survey before the show to contribute to the pool of responses.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T131500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T131500
+DTEND:20250727T134500
+SUMMARY:LEGO - Building a Career
+DESCRIPTION:Come learn how these panelists took their passion for building LEGO and turned it into a career. From corporate displays, to movies, to art.
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T133000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T133000
+DTEND:20250727T141500
+SUMMARY:Short Form Content
+DESCRIPTION:Why use many word when few do trick?
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T134500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T134500
+DTEND:20250727T141500
+SUMMARY:Indie Dev Roundtable "What makes a great demo"
+DESCRIPTION:
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T141500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T141500
+DTEND:20250727T150000
+SUMMARY:Backyard Science: Touching Grass
+DESCRIPTION:OfflineTV goes offline to help the Backyard Scientist explore some live stage science.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T141500-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T141500
+DTEND:20250727T144500
+SUMMARY:4D Printing
+DESCRIPTION:Join for a discussion of functional 3D printing, where parts have to play nice with each other and come together to form intricate sculptures and robust machines.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T144500-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T144500
+DTEND:20250727T151500
+SUMMARY:The Creative Process
+DESCRIPTION:Ideas are hard. From inspiration to execution, get an inside look at the creative journey behind the content.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T151500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T151500
+DTEND:20250727T154500
+SUMMARY:Farmer Consulting
+DESCRIPTION:Two “farmers” and one farmer walk into a panel…
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T151500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T151500
+DTEND:20250727T154500
+SUMMARY:Long Term Projects
+DESCRIPTION:Boats, bunkers, and beyond! Creators discuss their multi-part projects and try to convince you that they really will finish them someday. They swear.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T151500-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T151500
+DTEND:20250727T154500
+SUMMARY:Cosplay: Making From Pop Culture
+DESCRIPTION:These creators never learned the “fi” part of “sci-fi”. Join for a discussion of making the unreal, real and the metaphysical, physical.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T154500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T154500
+DTEND:20250727T164500
+SUMMARY:Pitching Your Game to Publishers
+DESCRIPTION:
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T154500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T154500
+DTEND:20250727T161500
+SUMMARY:Space (intentionally left blank)
+DESCRIPTION:Look up, and keep going for 60 something miles (100km).
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T160000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T160000
+DTEND:20250727T163000
+SUMMARY:Narrative-first YouTube Channel
+DESCRIPTION:Anyone who has built something and thought about making a YouTube video about it knows that building is only half the challenge. Telling a story around it is the other. Learn how they document the process, shape compelling stories, and turn complex projects into videos people want to watch.
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T161500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T161500
+DTEND:20250727T164500
+SUMMARY:Deep Dives: The Art of Saying More
+DESCRIPTION:Sometimes you just can’t fit everything into a TikTok. Long-form content gives creators space to explore complex topics and tell richer stories. This panel explores the craft of going deep: from research and storytelling, to keeping viewers engaged for the long haul.
+LOCATION:Main Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T163000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T163000
+DTEND:20250727T170000
+SUMMARY:You Don't Need to Crunch
+DESCRIPTION:
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T164500-OutdoorStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T164500
+DTEND:20250727T171500
+SUMMARY:Man vs. Machining
+DESCRIPTION:Taking a chip off the old block, literally. These creators harness giant metal machines to make (and break) precision parts. Stick around for thoughts on CNC-ing and machining with plenty of jargon along the way.
+LOCATION:Outdoor Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T170000-SecondStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T170000
+DTEND:20250727T174500
+SUMMARY:Voyagers of Nera Developers
+DESCRIPTION:
+LOCATION:Second Stage
+END:VEVENT
+BEGIN:VEVENT
+UID:20250727T171500-MainStage@opensauce
+DTSTAMP:20250724T193342
+DTSTART:20250727T171500
+DTEND:20250727T180000
+SUMMARY:Scare The Coyote: LIVE!
+DESCRIPTION:Join the cast and creators of Scare the Coyote for an exclusive live conversation and the inaugural live Golden Coyote Ceremony.
+LOCATION:Main Stage
+END:VEVENT
+END:VCALENDAR

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,56 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+header {
+    background: #333;
+    color: #fff;
+    padding: 1em;
+    text-align: center;
+}
+header .download {
+    display: inline-block;
+    margin-top: .5em;
+    background: #4CAF50;
+    color: #fff;
+    padding: .5em 1em;
+    text-decoration: none;
+    border-radius: 4px;
+}
+#tabs {
+    display: flex;
+    justify-content: center;
+    gap: .5em;
+    margin: 1em 0;
+}
+#tabs button {
+    padding: .5em 1em;
+    border: none;
+    background: #eee;
+    cursor: pointer;
+    border-radius: 4px;
+}
+#tabs button.active {
+    background: #333;
+    color: #fff;
+}
+#content {
+    padding: 0 1em 2em;
+}
+.event {
+    border-bottom: 1px solid #ccc;
+    padding: .5em 0;
+}
+.event h3 {
+    margin: .2em 0;
+}
+.event .time {
+    font-weight: bold;
+}
+@media (min-width: 600px) {
+    #content {
+        max-width: 600px;
+        margin: 0 auto;
+    }
+}

--- a/generate_ics.py
+++ b/generate_ics.py
@@ -1,0 +1,45 @@
+import json
+from datetime import datetime, timedelta
+
+with open('opensauce_schedule.json', 'r') as f:
+    schedule = json.load(f)
+
+DATE_MAP = {
+    'Friday': '20250725',
+    'Saturday': '20250726',
+    'Sunday': '20250727'
+}
+
+ics_lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//OpenSauce Schedule//EN',
+    'CALSCALE:GREGORIAN'
+]
+
+for day, date_str in DATE_MAP.items():
+    for event in schedule.get(day, []):
+        start_dt = datetime.strptime(f"{date_str} {event['time']}", "%Y%m%d %I:%M %p")
+        dur_minutes = 0
+        dur_token = event.get('duration', '').strip('()')
+        if dur_token:
+            try:
+                dur_minutes = int(dur_token.split()[0])
+            except (ValueError, IndexError):
+                dur_minutes = 0
+        end_dt = start_dt + timedelta(minutes=dur_minutes)
+        fmt = "%Y%m%dT%H%M%S"
+        ics_lines.append('BEGIN:VEVENT')
+        ics_lines.append(f"UID:{start_dt.strftime(fmt)}-{event['stage'].replace(' ', '')}@opensauce")
+        ics_lines.append(f"DTSTAMP:{datetime.utcnow().strftime(fmt)}")
+        ics_lines.append(f"DTSTART:{start_dt.strftime(fmt)}")
+        ics_lines.append(f"DTEND:{end_dt.strftime(fmt)}")
+        ics_lines.append(f"SUMMARY:{event['title']}")
+        ics_lines.append(f"DESCRIPTION:{event['description']}")
+        ics_lines.append(f"LOCATION:{event['stage']}")
+        ics_lines.append('END:VEVENT')
+
+ics_lines.append('END:VCALENDAR')
+
+with open('docs/opensauce_schedule.ics', 'w') as f:
+    f.write("\n".join(ics_lines))


### PR DESCRIPTION
## Summary
- generate an ICS calendar from the JSON schedule
- add `docs` directory with a responsive schedule webpage
- pull schedule data at runtime instead of embedding JSON

## Testing
- `python3 generate_ics.py`

------
https://chatgpt.com/codex/tasks/task_b_68828a2bc968832bb6e43ba9f841495a