### PR TITLE
Fix schedule load path

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1,5 +1,6 @@
 async function loadSchedule() {
-  const response = await fetch('../opensauce_schedule.json');
+  // Fetch the schedule JSON from the same directory as the webpage
+  const response = await fetch('opensauce_schedule.json');
   const data = await response.json();
   const content = document.getElementById('content');
   const tabs = document.querySelectorAll('#tabs button');

--- a/docs/opensauce_schedule.json
+++ b/docs/opensauce_schedule.json
@@ -1,0 +1,874 @@
+{
+  "Friday": [
+    {
+      "time": "09:30 AM",
+      "duration": "(10 mins)",
+      "stage": "Industry Stage",
+      "title": "Welcome to Open Sauce with William Osman",
+      "description": "Join the official kickoff of Open Sauce Year 3 with inventor and creator William Osman. This session will offer a quick look at the creator culture that drives innovation, audience connection, and creative business growth.",
+      "speakers": [
+        "Jim Louderback",
+        "William Osman"
+      ]
+    },
+    {
+      "time": "09:40 AM",
+      "duration": "(25 mins)",
+      "stage": "Industry Stage",
+      "title": "Scaling Content Across Borders",
+      "description": "As platforms grow globally, smart creators are discovering opportunity to distribute everywhere. This session lays out the advantages for global content expansion: greater ad revenue, new sponsorship options, and increased audience growth. Learn which tools, partners, and platforms are helping creators scale internationally - without scaling production.",
+      "speakers": [
+        "Dustin Harris",
+        "Jonny Steel",
+        "Corey Braun"
+      ]
+    },
+    {
+      "time": "10:05 AM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "If YouTube Died Tomorrow, Would Your Business?",
+      "description": "You don\u2019t own your followers. And if the algorithm turns on you\u2014or your platform disappears\u2014what happens next? This session explores how creators are future-proofing their business by owning their audiences and monetizing beyond the core social platforms. Learn how to take control of your community, revenue, and future - and stop relying on rented land.",
+      "speakers": [
+        "Kevin Daigle",
+        "Luria Petrucci",
+        "Brian McManus",
+        "Luke Lafreniere",
+        "Christian Eveleigh"
+      ]
+    },
+    {
+      "time": "10:35 AM",
+      "duration": "(25 mins)",
+      "stage": "Industry Stage",
+      "title": "Fireside Chat with Alex Wellen, President QVC",
+      "description": "Commerce has entered a bold new era. As the original disruptor in retail innovation, QVC Group is building the future of live, social, and immersive shopping. In this fireside chat, Alex Wellen, President and Chief Growth Officer of QVC Group, joins Jim Louderback to explore how the company is redefining the commerce experience\u2014scaling authentic storytelling, reaching new consumers, empowering fresh voices, and setting the standard for the future of shoppable media across all types of products \u2013 including those from makers, builders, scientists and geeks.",
+      "speakers": [
+        "Jim Louderback",
+        "Alex Wellen"
+      ]
+    },
+    {
+      "time": "11:00 AM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "Fireside Chat with Kevin Kelly and William Osman",
+      "description": "Kevin Kelly helped define digital optimism and shaped how we think about technology, communities, and creativity. In this live podcast recording and fireside chat with maker-creator William Osman, the Wired founding executive editor explore the real meaning behind 1,000 True Fans, the power of an \u201caudience of one,\u201d and why a little optimism is a good thing. Expect stories, frameworks, and timeless advice for everyone navigating the next era of the internet and life itself.",
+      "speakers": [
+        "William Osman"
+      ]
+    },
+    {
+      "time": "11:30 AM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "The Science of Memes and the Art of Relevance",
+      "description": "What do an etymology expert and an engineering creator have in common? Memes. In this surprising and fun session, Etymology Nerd Adam Aleksic and Patrick Lacey from Tier Zoo explore how meme culture powers both virality and connection. From shifting language to unexpected content formats, they\u2019ll explore what it really takes to stay relevant\u2014and respected\u2014online. You\u2019ll learn how to spot high-potential trends early, apply meme logic to serious content, and use humor to build lasting audience engagement.",
+      "speakers": [
+        "Adam Aleksic",
+        "Patrick Lacey",
+        "Morgan Sung"
+      ]
+    },
+    {
+      "time": "12:00 PM",
+      "duration": "(60 mins)",
+      "stage": "Industry Stage",
+      "title": "LUNCH",
+      "description": "",
+      "speakers": []
+    },
+    {
+      "time": "12:20 PM",
+      "duration": "(30 mins)",
+      "stage": "Breakout 3",
+      "title": "Roundtable with Tyler Chou",
+      "description": "Got a legal question? Wondering abou the law and creators? Bring your questions, thoughs and ideas to this round-table discussion with creator, lawyer, manager and creator advocate Tyler Chou.",
+      "speakers": [
+        "Tyler Chou"
+      ]
+    },
+    {
+      "time": "12:20 PM",
+      "duration": "(30 mins)",
+      "stage": "Breakout 1",
+      "title": "AMA With NASA Astronaut Matthew Dominick",
+      "description": "Straight from NASA to our stage, Matthew Dominick answers your boldest, weirdest, and most ambitious space questions - along with talking about what it's like to be a creator in space.",
+      "speakers": [
+        "Matthew Dominick"
+      ]
+    },
+    {
+      "time": "12:20 PM",
+      "duration": "(30 mins)",
+      "stage": "Breakout 2",
+      "title": "A Day in the life of Mark Rober's Creative Team",
+      "description": "Go behind the scenes with Mark Rober\u2019s creative team as they share insights into their workflow, problem-solving techniques, and the magic behind their viral projects. Bring your questions and ideas to this interactive AMA session and explore wild ideas, innovative production processes and more!",
+      "speakers": [
+        "Pojo Riegert",
+        "Jon Marcu"
+      ]
+    },
+    {
+      "time": "01:00 PM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "YouTube Algorithm Secrets - 2025",
+      "description": "YouTube's creator liaison and editor Rene Ritchie and YouTube product manager Todd Beaupre know more about building success on YouTube than just about anyone else. In this session they'll share the deep secrets of success for July 2025, including why the algorithm doesn't hate you, how AI is changing discovery and recommendations, the key numbers and KPIs to REALLY focus on, the unique characteristics of Shorts, YouTube on the big screen and much more! Get ready to really understand how the YouTube algorithm works from the inside experts at YouTube!",
+      "speakers": [
+        "Todd Beaupr\u00e9",
+        "Rene Ritchie",
+        "Gwen Miller"
+      ]
+    },
+    {
+      "time": "01:30 PM",
+      "duration": "(25 mins)",
+      "stage": "Industry Stage",
+      "title": "GM's Creator Playbook",
+      "description": "For GM, the road to the future isn\u2019t just about EVs and autonomous driving \u2013 it\u2019s about transforming how they engage with creators and redefine their brand for a digital-first world. Jessica Wang, Executive Director of Content Strategy at GM and former YouTube executive, shares how the legacy automaker is moving beyond traditional influencer campaigns to deeper, more authentic partnerships that treat creators like true creative collaborators. Learn why GM is betting on creators as strategic storytellers, how they\u2019re building relationships beyond the automotive world, and what this approach means for brands looking to connect with diverse, engaged audiences.",
+      "speakers": [
+        "Jessica Wang",
+        "Neil Waller"
+      ]
+    },
+    {
+      "time": "01:55 PM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "What Creators Wish Brands Knew",
+      "description": "Brands love working with creators\u2014until they don\u2019t. Misaligned expectations, bad briefs, and clunky approval processes can turn a dream deal into a disaster. In this session, top creators pull back the curtain on what brands get wrong (and right) when collaborating with influencers. From creative freedom to fair pay to authentic storytelling, hear firsthand what creators need from brands to deliver their best work\u2014and why some partnerships fail before they even begin. If you\u2019re a brand looking to build better, more effective creator relationships, this is the conversation you can\u2019t afford to miss.",
+      "speakers": [
+        "Cassandra Bankson",
+        "Monica Khan"
+      ]
+    },
+    {
+      "time": "02:25 PM",
+      "duration": "(25 mins)",
+      "stage": "Industry Stage",
+      "title": "What Brands Wish Creators Knew - Kamal Bhandal",
+      "description": "What makes a creator stand out\u2014or get cut? Kamal Bhandal, SVP of Global Invisalign Brand at Align Technology, shares what brands really look for, what kills a deal, and how creators can position themselves for long-term partnerships. Walk away with clear, insider tips to land brand deals and avoid common missteps.",
+      "speakers": [
+        "Kamal Bhandal",
+        "Eric Wei"
+      ]
+    },
+    {
+      "time": "02:50 PM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "Thriving as a Creator in the Age of AI",
+      "description": "These creators aren\u2019t scared of AI, they're adapting and thriving. 3 top creators share how they are integrating AI into their workflows today, and how they plan to differentiate their content from AI-generated slop tomorrow. From content production to audience growth, new formats and digital twins, they\u2019ll share what tools are working, what\u2019s still broken, and how they'll collaborate and compete with AI in the future.",
+      "speakers": [
+        "YC Sun",
+        "Delia Lazarescu",
+        "Rox Codes"
+      ]
+    },
+    {
+      "time": "03:30 PM",
+      "duration": "(40 mins)",
+      "stage": "Industry Stage",
+      "title": "AFTERNOON BREAK",
+      "description": "",
+      "speakers": []
+    },
+    {
+      "time": "03:35 PM",
+      "duration": "(30 mins)",
+      "stage": "Breakout 1",
+      "title": "Round Table With Rene Ritchie",
+      "description": "Join this round table / AMA with Rene Ritchie to talk YouTube algorithms, creating content and really anything on your mind!",
+      "speakers": [
+        "Todd Beaupr\u00e9",
+        "Rene Ritchie"
+      ]
+    },
+    {
+      "time": "03:35 PM",
+      "duration": "(30 mins)",
+      "stage": "Breakout 3",
+      "title": "Round Table Q&A: Setting Yourself Up for Brand Partnerships Success",
+      "description": "This facilitated discussion brings creators together to unpack the full brand partnerships journey. Whether you're represented or independent, you'll walk through the entire cycle\u2014from strategy to pitch to execution and renewal. Guided by Ben Smith from Smooth Media, you\u2019ll learn how to better define your audience, build effective media kits, and sustain long-term relationships. Share your experience, ask questions, and leave with tactical insights to help you start working with your dream brands.",
+      "speakers": [
+        "Ben Smith"
+      ]
+    },
+    {
+      "time": "03:35 PM",
+      "duration": "(30 mins)",
+      "stage": "Breakout 2",
+      "title": "Roundtable Conversation: What is a Creator in the Age of AI",
+      "description": "AI is reshaping the creative process. This roundtable, led by YC Sun and Dan Perkel of IDEO, offers an interactive forum for creators, marketers and experts to discuss the practical, personal, and ethical questions raised in \u201cThriving as a Creator in the Age of AI.\u201d Bring your ideas, frustrations, questions and code. You'll leave with new strategies, peer insights, and possible collaborations.",
+      "speakers": [
+        "YC Sun",
+        "Dan Perkel"
+      ]
+    },
+    {
+      "time": "04:10 PM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "Explaining the Universe One Click at a Time",
+      "description": "From backyard explosions to big-bang theories, science hits different when it\u2019s told by creators who love to tinker, test, and ask \u201cwhat if?\u201d This session dives into how hands-on creators and lifelong explainers are turning curiosity into content that sticks\u2014and why making people feel science might matter more than making them memorize it. Get practical strategies to create, build, fund, and scale science communication in a platform-first world.",
+      "speakers": [
+        "Matthew Dominick",
+        "Ian Charnas",
+        "Trace Dominguez"
+      ]
+    },
+    {
+      "time": "04:40 PM",
+      "duration": "(25 mins)",
+      "stage": "Industry Stage",
+      "title": "From Tech Journalist to Brand Insider",
+      "description": "Dan Ackerman spent years running major tech sites, including Gizmodo and CNET. Now he\u2019s internal editor-in-chief at MicroCenter. What\u2019s it like to go from covering the industry to working inside it? Joined by creator and MicroCenter SuperFan Michael Reeves, this session explores the evolving role of media, the rise of internal creators, and what the future looks like for building PCs and telling tech stories.",
+      "speakers": [
+        "Dan Ackerman",
+        "Michael Reeves"
+      ]
+    },
+    {
+      "time": "05:05 PM",
+      "duration": "(25 mins)",
+      "stage": "Industry Stage",
+      "title": "Likes Don\u2019t Pay Rent - Fireside Chat with Patreon COO Paige Fitzgerald",
+      "description": "This fireside chat with Patreon COO Paige Fitzgerald explores how creators are moving beyond ad models and algorithm churn to build real, recurring revenue. Drawing on insights from Patreon\u2019s latest State of the Creator report and real world examples, the session will explore what sustainable success looks like today. Whether you're a creator, a platform builder, or a brand investing in talent, this conversation offers a clear look at what it takes to build a lasting creative business.",
+      "speakers": [
+        "Paige Fitzgerald"
+      ]
+    },
+    {
+      "time": "05:30 PM",
+      "duration": "(30 mins)",
+      "stage": "Industry Stage",
+      "title": "From YouTube Clickbait to Real Engineering",
+      "description": "We\u2019re closing out industry day with a conversation with top creators who are pushing the boundaries of internet innovation through hands-on engineering and practical product development. From prototyping physical products to launching new tools with AI, this session dives into the serious side of making on the internet. You'll leave with insight into how creators are evolving beyond content into real-world problem-solving and what\u2019s inspiring them to keep building.",
+      "speakers": [
+        "William Osman"
+      ]
+    },
+    {
+      "time": "06:30 PM",
+      "duration": "(120 mins)",
+      "stage": "Off-Site",
+      "title": "Industry Reception",
+      "description": "",
+      "speakers": []
+    }
+  ],
+  "Saturday": [
+    {
+      "time": "10:30 AM",
+      "duration": "(45 mins)",
+      "stage": "Main Stage",
+      "title": "Safety Third: LIVE!",
+      "description": "Safety Third but it's LIVE! The hosts (and some guests) share stories and rant while pretending to talk about science.",
+      "speakers": [
+        "NileRed",
+        "The Backyard Scientist",
+        "William Osman",
+        "Michael Reeves",
+        "Emily The Engineer"
+      ]
+    },
+    {
+      "time": "11:00 AM",
+      "duration": "(30 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Innovating In A Niche",
+      "description": "Some people chase trends, but these creators have built strong, loyal audiences by sticking to what they love and finding others who love it too. Hear how to turn niche ideas into standout content.",
+      "speakers": [
+        "Engineezy",
+        "Ali Spagnola",
+        "Alan Becker",
+        "Gavin Free"
+      ]
+    },
+    {
+      "time": "11:15 AM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Prototyping to Product",
+      "description": "Making one cool thing for a YouTube video is tough enough, but turning that idea into 10,000 units is a whole different challenge. Learn how these creators have taken their custom-built projects from prototype to product.",
+      "speakers": [
+        "The Hacksmith",
+        "Jake Laser",
+        "JerryRigEverything",
+        "Unnecessary Inventions",
+        "Stephen Hawes"
+      ]
+    },
+    {
+      "time": "12:00 PM",
+      "duration": "(45 mins)",
+      "stage": "Main Stage",
+      "title": "The BackYard - Agains",
+      "description": "We\u2019re back! Join as the cast of The Yard returns for more Backyard Science in the squeak-uel we've all been waiting for.",
+      "speakers": [
+        "Ludwig",
+        "Nick",
+        "Slime"
+      ]
+    },
+    {
+      "time": "12:45 PM",
+      "duration": "(45 mins)",
+      "stage": "Second Stage",
+      "title": "Team Rocket",
+      "description": "Join us to nerd out over thrust vectors, propellants, shock diamonds, and more rocket words! It's gonna rock(et).",
+      "speakers": [
+        "BPS.space",
+        "Integza",
+        "SmarterEveryDay",
+        "Scott Manley",
+        "Brigette Oakes"
+      ]
+    },
+    {
+      "time": "01:00 PM",
+      "duration": "(30 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Robotics and Animatronics!",
+      "description": "What if the robots could move?",
+      "speakers": [
+        "Odd_Jayy",
+        "Kiara\u2019s Workshop",
+        "Wicked Makers",
+        "Becky Stern",
+        "Aaed Musa"
+      ]
+    },
+    {
+      "time": "01:30 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "Could AI Make This Panel?",
+      "description": "It - made - this - description!",
+      "speakers": [
+        "Jabrils",
+        "Captain Disillusion",
+        "ThePrimeagen",
+        "Luke Lafreniere"
+      ]
+    },
+    {
+      "time": "01:30 PM",
+      "duration": "(45 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Planes, Trains, and Automobiles",
+      "description": "Walking is overrated. This gang of creators prefers to drive, fly and float their way around.",
+      "speakers": [
+        "Peter Sripol",
+        "Tom Stanton",
+        "rctestflight",
+        "Ramy RC",
+        "Aging Wheels",
+        "Quiet Nerd"
+      ]
+    },
+    {
+      "time": "01:30 PM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "It's All About Chemistry",
+      "description": "We all know \"Chemistry is the scientific study of matter, its properties, and how it changes during chemical reactions. It explores the building blocks of the universe such as atoms and molecules and how they interact to form everything from water to DNA. Chemistry connects the physical world with biological and environmental systems\", and this panel connects you with your favorite chemistry creators. Will they bond?",
+      "speakers": [
+        "NileRed",
+        "Cody's Lab",
+        "Explosions&Fire",
+        "Styropyro",
+        "The Thought Emporium"
+      ]
+    },
+    {
+      "time": "02:00 PM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Streaming AMA",
+      "description": "It doesn't get more live than this. Chat with top streaming creators in this Q&A panel. Questions for the panel must be submitted in advance via the event app.",
+      "speakers": [
+        "Bao The Whale",
+        "Codemiko",
+        "DisguisedToast",
+        "Sydeon",
+        "Yvonnie",
+        "Scarra"
+      ]
+    },
+    {
+      "time": "02:00 PM",
+      "duration": "(60 mins)",
+      "stage": "Second Stage",
+      "title": "Let's make a game in an hour",
+      "description": "",
+      "speakers": [
+        "Kevin Laird"
+      ]
+    },
+    {
+      "time": "02:15 PM",
+      "duration": "(30 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Unconventional Materials",
+      "description": "Wood, metal, and plastic are fine...but why stop there? How to make something from anything.",
+      "speakers": [
+        "Peter Brown",
+        "Bobby Duke Arts",
+        "Morley Kert",
+        "Ali Spagnola",
+        "Crescent Shay"
+      ]
+    },
+    {
+      "time": "02:30 PM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "State of The Union",
+      "description": "Over the past two decades, content creation has evolved from webcam vlogs into a multi-billion-dollar industry. Join us as we chat about the shifts in platforms, audiences, algorithms, and where we might be headed next.",
+      "speakers": [
+        "Hank Green",
+        "Vsauce",
+        "Gavin Free",
+        "Arin Hanson"
+      ]
+    },
+    {
+      "time": "03:00 PM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Super Villain Inc.",
+      "description": "Trapped in an entry level job, creators are forced to innovate at the will of an evil corporate overlord. Watch as they navigate a game of ethics, corporate bureaucracy, and the laws of physics. Will there be synergy?",
+      "speakers": [
+        "Colin Furze",
+        "Styropyro",
+        "Michael Reeves",
+        "Allen Pan",
+        "ElectroBOOM"
+      ]
+    },
+    {
+      "time": "03:15 PM",
+      "duration": "(45 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Meet the Bot Builders, ask them anything!",
+      "description": "A discussion with some of the most famous builders in BattleBots. We will talk about BattleBots Faceoffs and some recent YouTube creators and bot builders collaborations then open it up to questions. Builders: Ray Billings: Tombstone (World Champion and Most Destructive Robot Award), Leanne Cushing: Valkyrie (Most Destructive Robot Award), Nick Dobrikov: Manta, Jen Herochender: Hijinx, Aren Hill: Tantrum, Blip (World Champion), Bunny Liaw: Malice, Zach Lytle: Skorpios and Derek Tran: Cobalt, Gigabyte",
+      "speakers": []
+    },
+    {
+      "time": "03:30 PM",
+      "duration": "(60 mins)",
+      "stage": "Second Stage",
+      "title": "Why you need a producer",
+      "description": "",
+      "speakers": [
+        "Matt Warl"
+      ]
+    },
+    {
+      "time": "04:00 PM",
+      "duration": "(45 mins)",
+      "stage": "Main Stage",
+      "title": "Carp Tank",
+      "description": "Open Sauce exhibitors team up with creators to pitch their projects to a panel of vicious business carp. Will the ideas (and their inventors) sink or swim under the pressure?",
+      "speakers": [
+        "William Osman",
+        "TechJoyce",
+        "Unnecessary Inventions",
+        "Kyle Hill",
+        "Evan and Katelyn",
+        "Ruth Amos"
+      ]
+    },
+    {
+      "time": "04:30 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "gnireenignE: Reverse Engineering",
+      "description": ".gnireenigne s'taht won ,rehtegot kcab meht gnittup ,trapA sgniht gnikaT",
+      "speakers": [
+        "Strange Parts",
+        "Jeff Geerling",
+        "Ben Krasnow",
+        "Ben Eater",
+        "Jeremy Fielding"
+      ]
+    },
+    {
+      "time": "05:00 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "3D Printing Hot Takes",
+      "description": "From failed first layers, to funky filaments, and a billion \u201cBenchy\u2019s\u201d: these creators' and their 3D printing opinions are like onions (they have layers). Join them for a layered discussion about printers, slicers, and so many layers.",
+      "speakers": [
+        "CNC Kitchen",
+        "Thomas Sanladerer",
+        "Emily The Engineer",
+        "Allen Pan"
+      ]
+    },
+    {
+      "time": "05:00 PM",
+      "duration": "(45 mins)",
+      "stage": "Main Stage",
+      "title": "Are you dumber than a sixth grader?",
+      "description": "Four creators vs four sixth graders. Who will win?",
+      "speakers": [
+        "NileRed",
+        "SmarterEveryDay",
+        "Atarabyte",
+        "Ted Nivison"
+      ]
+    },
+    {
+      "time": "05:30 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "Doing It The Hard Way (Ye' Olde Makers)",
+      "description": "Ignoring the advances of technology over the past few decades is\u2026 a choice.",
+      "speakers": [
+        "Cody's Lab",
+        "How To Make Everything",
+        "Bobby Duke Arts",
+        "FarmCraft101"
+      ]
+    }
+  ],
+  "Sunday": [
+    {
+      "time": "10:30 AM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "YouTube Shop Talk: Ask Us Anything!",
+      "description": "Talk shop with top creators in this Q&A panel. Questions for the panel must be submitted in advance via the event app.",
+      "speakers": [
+        "Estefannie",
+        "CNC Kitchen",
+        "Luke Lafreniere",
+        "Grady Hillhouse",
+        "Skip the Tutorial"
+      ]
+    },
+    {
+      "time": "10:30 AM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Movie Magic: VFX",
+      "description": "These magicians WILL share their secrets.",
+      "speakers": [
+        "Nick Laurant",
+        "Captain Disillusion",
+        "Sam Wickert",
+        "Brendan Forde"
+      ]
+    },
+    {
+      "time": "10:45 AM",
+      "duration": "(45 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Experimental Panel Title",
+      "description": "Never let them know your next move. When these creators post, you never know what you\u2019re gonna get. Come learn about how a sidequest can spiral into something bigger and what to do when you\u2019re interested in everything.",
+      "speakers": [
+        "The Action Lab",
+        "Waterjet Channel",
+        "NightHawkInLight",
+        "Alpha Phoenix",
+        "The Thought Emporium",
+        "Joel Creates"
+      ]
+    },
+    {
+      "time": "11:00 AM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "Mammoth Mistake? Conservation and Human Interference",
+      "description": "From ancient extinction to modern ecosystems, the line between conservation and interference is blurrier than ever. Should we bring species back? How do we protect what\u2019s still here? And what role should humans play in shaping nature\u2019s future?",
+      "speakers": [
+        "Maya Higa",
+        "Emily Graslie",
+        "TierZoo"
+      ]
+    },
+    {
+      "time": "11:15 AM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Developing Content on Developing Games",
+      "description": "These creators know it ain\u2019t all fun and games. Find out how these developer creators juggle developing games and developing content about developing games as this panel develops.",
+      "speakers": [
+        "SonderingEmily",
+        "Code Bullet",
+        "PolyMars",
+        "Luke Muscat"
+      ]
+    },
+    {
+      "time": "11:45 AM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "The Future of Animation",
+      "description": "From hand-drawn cells to AI-assisted workflows, animation is evolving faster than ever. This panel brings together creators who are pushing the boundaries of style, technology, and storytelling. Explore where animation is headed, how it is being made, and what the next generation of animators and audiences can expect.",
+      "speakers": [
+        "TheOdd1sOut",
+        "Rebecca Parham",
+        "CircleToonsHD",
+        "illymation",
+        "Alan Becker",
+        "Audity"
+      ]
+    },
+    {
+      "time": "12:15 PM",
+      "duration": "(45 mins)",
+      "stage": "Second Stage",
+      "title": "Learning is Fun: Educating on Educational Content",
+      "description": "Science education doesn\u2019t have to be dry. Learn how these creators navigate mixing entertainment with education.",
+      "speakers": [
+        "Tibees",
+        "TierZoo",
+        "Grady Hillhouse",
+        "Emily Graslie",
+        "ChubbyEmu",
+        "The Coding Train",
+        "Astro Alexandra"
+      ]
+    },
+    {
+      "time": "12:45 PM",
+      "duration": "(45 mins)",
+      "stage": "Main Stage",
+      "title": "Creator Feud",
+      "description": "Join us for a second annual game of Creator Feud, where your answers shape the game! Be sure to complete our survey before the show to contribute to the pool of responses.",
+      "speakers": [
+        "PointCrow",
+        "Slimecicle",
+        "Ranboo",
+        "ConnorEatsPants",
+        "ThePrimeagen",
+        "Explosions&Fire",
+        "Nerdforge",
+        "Allen Pan",
+        "ElectroBOOM",
+        "Technology Connections"
+      ]
+    },
+    {
+      "time": "01:15 PM",
+      "duration": "(30 mins)",
+      "stage": "Outdoor Stage",
+      "title": "LEGO - Building a Career",
+      "description": "Come learn how these panelists took their passion for building LEGO and turned it into a career. From corporate displays, to movies, to art.",
+      "speakers": [
+        "Brandon Griffith",
+        "Tommy Williamson",
+        "Chris Wight",
+        "Sam Builds"
+      ]
+    },
+    {
+      "time": "01:30 PM",
+      "duration": "(45 mins)",
+      "stage": "Second Stage",
+      "title": "Short Form Content",
+      "description": "Why use many word when few do trick?",
+      "speakers": [
+        "AstroKobi",
+        "Emily The Engineer",
+        "Unnecessary Inventions",
+        "Atarabyte",
+        "Joseph\u2019s Machines",
+        "Rachel Pizzolato"
+      ]
+    },
+    {
+      "time": "01:45 PM",
+      "duration": "(30 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Indie Dev Roundtable \"What makes a great demo\"",
+      "description": "",
+      "speakers": [
+        "Gemporium Devs"
+      ]
+    },
+    {
+      "time": "02:15 PM",
+      "duration": "(45 mins)",
+      "stage": "Main Stage",
+      "title": "Backyard Science: Touching Grass",
+      "description": "OfflineTV goes offline to help the Backyard Scientist explore some live stage science.",
+      "speakers": [
+        "Michael Reeves",
+        "QuarterJade",
+        "Masayoshi",
+        "LilyPichu",
+        "Pokimane"
+      ]
+    },
+    {
+      "time": "02:15 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "4D Printing",
+      "description": "Join for a discussion of functional 3D printing, where parts have to play nice with each other and come together to form intricate sculptures and robust machines.",
+      "speakers": [
+        "Sean Hodgins",
+        "Engineezy",
+        "Ivan Miranda",
+        "3D Printing Nerd"
+      ]
+    },
+    {
+      "time": "02:45 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "The Creative Process",
+      "description": "Ideas are hard. From inspiration to execution, get an inside look at the creative journey behind the content.",
+      "speakers": [
+        "Evan and Katelyn",
+        "Ten Hundred",
+        "Nerdforge",
+        "TheOdd1sOut"
+      ]
+    },
+    {
+      "time": "03:15 PM",
+      "duration": "(30 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Farmer Consulting",
+      "description": "Two \u201cfarmers\u201d and one farmer walk into a panel\u2026",
+      "speakers": [
+        "William Osman",
+        "The Backyard Scientist",
+        "FarmCraft101"
+      ]
+    },
+    {
+      "time": "03:15 PM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Long Term Projects",
+      "description": "Boats, bunkers, and beyond! Creators discuss their multi-part projects and try to convince you that they really will finish them someday. They swear.",
+      "speakers": [
+        "Nate From the Internet",
+        "Peter Sripol",
+        "Colin Furze",
+        "Brent Underwood",
+        "Quiet Nerd",
+        "How To Make Everything"
+      ]
+    },
+    {
+      "time": "03:15 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "Cosplay: Making From Pop Culture",
+      "description": "These creators never learned the \u201cfi\u201d part of \u201csci-fi\u201d. Join for a discussion of making the unreal, real and the metaphysical, physical.",
+      "speakers": [
+        "Stella Chuu",
+        "Crescent Shay",
+        "LittleJem",
+        "Sam Meeps",
+        "Kiara\u2019s Workshop"
+      ]
+    },
+    {
+      "time": "03:45 PM",
+      "duration": "(60 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Pitching Your Game to Publishers",
+      "description": "",
+      "speakers": [
+        "Offbrand Games",
+        "Akupara"
+      ]
+    },
+    {
+      "time": "03:45 PM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Space (intentionally left blank)",
+      "description": "Look up, and keep going for 60 something miles (100km).",
+      "speakers": [
+        "AstroKobi",
+        "Astro Alexandra",
+        "Scott Manley",
+        "Brian McManus",
+        "Matthew Dominick"
+      ]
+    },
+    {
+      "time": "04:00 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "Narrative-first YouTube Channel",
+      "description": "Anyone who has built something and thought about making a YouTube video about it knows that building is only half the challenge. Telling a story around it is the other. Learn how they document the process, shape compelling stories, and turn complex projects into videos people want to watch.",
+      "speakers": [
+        "Sean Hodgins",
+        "Jake Laser",
+        "Allen Pan"
+      ]
+    },
+    {
+      "time": "04:15 PM",
+      "duration": "(30 mins)",
+      "stage": "Main Stage",
+      "title": "Deep Dives: The Art of Saying More",
+      "description": "Sometimes you just can\u2019t fit everything into a TikTok. Long-form content gives creators space to explore complex topics and tell richer stories. This panel explores the craft of going deep: from research and storytelling, to keeping viewers engaged for the long haul.",
+      "speakers": [
+        "Technology Connections",
+        "Tibees",
+        "Alpha Phoenix",
+        "Hbomberguy",
+        "Ted Nivison"
+      ]
+    },
+    {
+      "time": "04:30 PM",
+      "duration": "(30 mins)",
+      "stage": "Second Stage",
+      "title": "You Don't Need to Crunch",
+      "description": "",
+      "speakers": [
+        "PolyMars"
+      ]
+    },
+    {
+      "time": "04:45 PM",
+      "duration": "(30 mins)",
+      "stage": "Outdoor Stage",
+      "title": "Man vs. Machining",
+      "description": "Taking a chip off the old block, literally. These creators harness giant metal machines to make (and break) precision parts. Stick around for thoughts on CNC-ing and machining with plenty of jargon along the way.",
+      "speakers": [
+        "Jeremy Fielding",
+        "Inheritance Machining",
+        "Marius Hornberger",
+        "Tom Stanton"
+      ]
+    },
+    {
+      "time": "05:00 PM",
+      "duration": "(45 mins)",
+      "stage": "Second Stage",
+      "title": "Voyagers of Nera Developers",
+      "description": "",
+      "speakers": []
+    },
+    {
+      "time": "05:15 PM",
+      "duration": "(45 mins)",
+      "stage": "Main Stage",
+      "title": "Scare The Coyote: LIVE!",
+      "description": "Join the cast and creators of Scare the Coyote for an exclusive live conversation and the inaugural live Golden Coyote Ceremony.",
+      "speakers": [
+        "Alex Ernst",
+        "Jabrils",
+        "Styropyro",
+        "Michael Reeves",
+        "NileRed",
+        "The Backyard Scientist",
+        "Emily The Engineer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- copy `opensauce_schedule.json` to the `docs` folder so it is served by GitHub Pages
- update JavaScript to load the schedule from that location

## Testing
- `python generate_ics.py`

------
https://chatgpt.com/codex/tasks/task_b_68894626da94832babe5e28cf8bc2a31