### PR TITLE
Add calendar view to OpenSauce schedule

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
 <button data-day="Sunday">Sunday, July 27</button>
 </nav>
 <section id="content"></section>
+<section id="calendar"></section>
 <script src="main.js"></script>
 </body>
 </html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -3,6 +3,7 @@ async function loadSchedule() {
   const response = await fetch('opensauce_schedule.json');
   const data = await response.json();
   const content = document.getElementById('content');
+  const calendar = document.getElementById('calendar');
   const tabs = document.querySelectorAll('#tabs button');
 
   function render(day) {
@@ -30,6 +31,68 @@ async function loadSchedule() {
   });
 
   render('Friday');
+  renderCalendar(data);
+}
+
+function parseTo24h(t) {
+  const [time, mer] = t.split(' ');
+  let [h, m] = time.split(':');
+  h = parseInt(h, 10);
+  if (mer === 'PM' && h !== 12) h += 12;
+  if (mer === 'AM' && h === 12) h = 0;
+  return `${h.toString().padStart(2, '0')}:${m}`;
+}
+
+function renderCalendar(data) {
+  const days = ['Friday', 'Saturday', 'Sunday'];
+  const slots = [];
+  for (let h = 9; h <= 17; h++) {
+    slots.push(`${h.toString().padStart(2, '0')}:00`);
+    slots.push(`${h.toString().padStart(2, '0')}:30`);
+  }
+  slots.push('18:00');
+
+  const map = {};
+  days.forEach(d => (map[d] = {}));
+  days.forEach(day => {
+    data[day].forEach(ev => {
+      const slot = parseTo24h(ev.time);
+      if (!map[day][slot]) map[day][slot] = [];
+      map[day][slot].push(ev);
+    });
+  });
+
+  const table = document.createElement('table');
+  table.id = 'calendar-table';
+  const thead = document.createElement('thead');
+  thead.innerHTML = '<tr><th>Time</th><th>Friday</th><th>Saturday</th><th>Sunday</th></tr>';
+  table.appendChild(thead);
+  const tbody = document.createElement('tbody');
+
+  slots.forEach(slot => {
+    const tr = document.createElement('tr');
+    const th = document.createElement('th');
+    th.textContent = slot;
+    tr.appendChild(th);
+    days.forEach(day => {
+      const td = document.createElement('td');
+      const events = map[day][slot];
+      if (events) {
+        events.forEach(e => {
+          const div = document.createElement('div');
+          div.className = 'cal-event';
+          div.textContent = `${e.title} (${e.stage})`;
+          td.appendChild(div);
+        });
+      }
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+
+  calendar.innerHTML = '';
+  calendar.appendChild(table);
 }
 
 loadSchedule();

--- a/docs/style.css
+++ b/docs/style.css
@@ -72,3 +72,29 @@ header .download {
         margin: 0 auto;
     }
 }
+
+/* Calendar table */
+#calendar {
+    overflow-x: auto;
+    margin: 2em 0;
+}
+
+#calendar-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#calendar-table th, #calendar-table td {
+    border: 1px solid #ccc;
+    padding: 0.5em;
+    vertical-align: top;
+}
+
+#calendar-table th {
+    background: #333;
+    color: #fff;
+}
+
+.cal-event {
+    margin-bottom: 0.25em;
+}


### PR DESCRIPTION
## Summary
- add a `calendar` section to index.html
- create basic table styling for the calendar
- build calendar grid in JavaScript using commercial hours

## Testing
- `python generate_ics.py`

------
https://chatgpt.com/codex/tasks/task_b_688a4cb6d8a0832ba27cd2c196f17f0c